### PR TITLE
[CPNHUB-35] config: Open coverage content in same page

### DIFF
--- a/server/data/ui_config.json
+++ b/server/data/ui_config.json
@@ -99,5 +99,11 @@
             ]
         },
         "search": true
+    },
+    {
+        "_id": "agenda",
+        "init_version": 1,
+        "multi_select_topics": false,
+        "open_coverage_content_in_same_page": true
     }
 ]


### PR DESCRIPTION
Also disable selecting multiple Topics in Agenda (same as in the Wire view)