### PR TITLE
tweak hypercorn workers config

### DIFF
--- a/server/hypercorn_config.py
+++ b/server/hypercorn_config.py
@@ -1,8 +1,12 @@
 import os
+import multiprocessing
+
+DEFAULT_MAX_WORKERS = 8
 
 bind = "0.0.0.0:%s" % os.environ.get("PORT", "5000")
-workers = int(os.environ.get("WEB_CONCURRENCY", 3))
-timeout = int(os.environ.get("WEB_TIMEOUT", 30))
+default_workers = min(multiprocessing.cpu_count() + 1, DEFAULT_MAX_WORKERS)
+workers = int(os.environ.get("WEB_CONCURRENCY", default_workers))
+read_timeout = int(os.environ.get("WEB_TIMEOUT", 30))
 
 accesslog = "-"
 access_log_format = "%(m)s %(U)s status=%(s)s time=%(T)ss size=%(B)sb"


### PR DESCRIPTION
add default based on cpu count + 1, with a top limit of 8